### PR TITLE
Safari issue with images if source is base64 data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,9 +74,14 @@ class ReactToPrint extends React.Component {
     };
 
     [...imageNodes].forEach((child) => {
+      /** Workaround for Safari if the image has base64 data as a source */
+      if (/^data:/.test(child.src)) {
+        child.crossOrigin = 'anonymous';
+      }
       child.setAttribute('src', child.src);
       child.onload = markLoaded.bind(null, 'image');
       child.onerror = markLoaded.bind(null, 'image');
+      child.crossOrigin = 'use-credentials';
     });
 
     /*


### PR DESCRIPTION
I've found that Safari doesn't execute onload if image has base64 data in src. As a result, target.print() will not be triggered.

I came up with a weird workaround, but it works for me. Looks like other browsers are ok with that :)