### PR TITLE
Add bodyClass prop to pass class to printWindow body

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,5 @@ The component accepts the following props:
 |**`copyStyles`**|boolean|Copies all &lt;style> and &lt;link type="stylesheet" /> from <head> inside the parent window into the print window. (default: true)
 |**`onBeforePrint`**|function|A callback function that triggers before print
 |**`onAfterPrint`**|function|A callback function that triggers after print
+|**`closeAfterPrint`**|boolean|Close the print window after action
+|**`bodyClass`**|string|Optional class to pass to the print window body

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ class ReactToPrint extends React.Component {
     onAfterPrint: PropTypes.func,
     /** Close the print window after action */
     closeAfterPrint: PropTypes.bool,
+    /** Optional class to pass to the print window body */
+    bodyClass: PropTypes.string,
     /** Debug Mode */
     debug: PropTypes.bool
   };
@@ -24,6 +26,7 @@ class ReactToPrint extends React.Component {
   static defaultProps = {
     copyStyles: true,
     closeAfterPrint: true,
+    bodyClass: '',
     debug: false
   };
 
@@ -145,6 +148,10 @@ class ReactToPrint extends React.Component {
     if (document.body.className) {
       const bodyClasses = document.body.className.split(" ");
       bodyClasses.map(item => printWindow.document.body.classList.add(item));
+    }
+    
+    if (this.props.bodyClass.length) {
+      printWindow.document.body.classList.add(this.props.bodyClass);
     }
 
     /* remove date/time from top */


### PR DESCRIPTION
An optional class can be passed to the `printWindow` body with the `bodyClass` prop.

Also updates the readme with new props.