### PR TITLE
trim redundant leading slashes from styles url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,8 @@ class ReactToPrint extends React.Component {
             const relPath = attr.nodeValue.substr(0, 3) === "../" 
               ? document.location.pathname.replace(/[^/]*$/, '') 
               : "/";
-            
+
+            nodeValue = nodeValue.replace(/\/+/, '');
             nodeValue = document.location.protocol + '//' + document.location.host + relPath + nodeValue;
             
           }


### PR DESCRIPTION
solves the problem described in https://github.com/gregnb/react-to-print/issues/11 by trimming redundant slashes from styles url