### PR TITLE
Fixed: Uncaught DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,9 @@ class ReactToPrint extends React.Component {
 
     if (document.body.className) {
       const bodyClasses = document.body.className.split(" ");
-      bodyClasses.map(item => printWindow.document.body.classList.add(item));
+      bodyClasses
+          .filter((item) => item)
+          .map(item => printWindow.document.body.classList.add(item));
     }
     
     if (this.props.bodyClass.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ class ReactToPrint extends React.Component {
     if (document.body.className) {
       const bodyClasses = document.body.className.split(" ");
       bodyClasses
-          .filter((item) => item)
+          .filter(item => item)
           .map(item => printWindow.document.body.classList.add(item));
     }
     


### PR DESCRIPTION
Turns out, if you have an empty class in `document.body.className` it'll cause an exception during `printWindow.document.body.classList.add`. We need to filter out those classnames before passing them on.