### PR TITLE
Prop to pass options to window.open()

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,5 @@ The component accepts the following props:
 |**`copyStyles`**|boolean|Copies all &lt;style> and &lt;link type="stylesheet" /> from <head> inside the parent window into the print window. (default: true)
 |**`onBeforePrint`**|function|A callback function that triggers before print
 |**`onAfterPrint`**|function|A callback function that triggers after print
+|**`closeAfterPrint`**|boolean|Close the print window after action
+|**`bodyClass`**|string|Optional class to pass to the print window body

--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ The component accepts the following props:
 |**`onAfterPrint`**|function|A callback function that triggers after print
 |**`closeAfterPrint`**|boolean|Close the print window after action
 |**`bodyClass`**|string|Optional class to pass to the print window body
-|**`printWindowOptions`**|object|Options to pass to the third argument of window.open(). Removes and overrides default properties. 
+|**`printWindowOptions`**|object|Options to pass to the third argument of `window.open()`. Removes and overrides default properties. 

--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ The component accepts the following props:
 |**`onAfterPrint`**|function|A callback function that triggers after print
 |**`closeAfterPrint`**|boolean|Close the print window after action
 |**`bodyClass`**|string|Optional class to pass to the print window body
+|**`printWindowOptions`**|object|Options to pass to the third argument of window.open(). Removes and overrides default properties. 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ class ReactToPrint extends React.Component {
     closeAfterPrint: PropTypes.bool,
     /** Optional class to pass to the print window body */
     bodyClass: PropTypes.string,
+    /** Options to pass to the third argument of window.open() */
+    printWindowOptions: PropTypes.shape({}),
     /** Debug Mode */
     debug: PropTypes.bool
   };
@@ -27,6 +29,11 @@ class ReactToPrint extends React.Component {
     copyStyles: true,
     closeAfterPrint: true,
     bodyClass: '',
+    printWindowOptions: {
+      status: 'no',
+      toolbar: 'no',
+      scrollbars: 'yes',
+    },
     debug: false
   };
 
@@ -51,8 +58,10 @@ class ReactToPrint extends React.Component {
       copyStyles,
       onAfterPrint
     } = this.props;
+    
+    const mappedPrintWindowOptions = Object.keys(printWindowOptions).map(m => `${m}=${printWindowOptions[m]}`).join(', ');
 
-    let printWindow = window.open("", "Print", "status=no, toolbar=no, scrollbars=yes", "false");
+    let printWindow = window.open('', 'Print', mappedPrintWindowOptions, 'false');
     
     if (onAfterPrint) {
       printWindow.onbeforeunload = onAfterPrint;

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ class ReactToPrint extends React.Component {
     onAfterPrint: PropTypes.func,
     /** Close the print window after action */
     closeAfterPrint: PropTypes.bool,
+    /** Optional class to pass to the print window body */
+    bodyClass: PropTypes.string,
     /** Debug Mode */
     debug: PropTypes.bool
   };
@@ -24,6 +26,7 @@ class ReactToPrint extends React.Component {
   static defaultProps = {
     copyStyles: true,
     closeAfterPrint: true,
+    bodyClass: '',
     debug: false
   };
 
@@ -145,6 +148,10 @@ class ReactToPrint extends React.Component {
     if (document.body.className) {
       const bodyClasses = document.body.className.split(" ");
       bodyClasses.map(item => printWindow.document.body.classList.add(item));
+    }
+    
+    if (this.props.bodyClass.length) {
+      printWindow.document.body.classList.add(this.props.bodyClass);
     }
 
     /* remove date/time from top */

--- a/src/index.js
+++ b/src/index.js
@@ -165,10 +165,6 @@ class ReactToPrint extends React.Component {
     if (this.props.bodyClass.length) {
       printWindow.document.body.classList.add(this.props.bodyClass);
     }
-    
-    if (this.props.bodyClass.length) {
-      printWindow.document.body.classList.add(this.props.bodyClass);
-    }
 
     /* remove date/time from top */
     let styleEl = printWindow.document.createElement('style');

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,8 @@ class ReactToPrint extends React.Component {
     const {
       content,
       copyStyles,
-      onAfterPrint
+      onAfterPrint,
+      printWindowOptions
     } = this.props;
     
     const mappedPrintWindowOptions = Object.keys(printWindowOptions).map(m => `${m}=${printWindowOptions[m]}`).join(', ');


### PR DESCRIPTION
Adds a prop so that custom values can be passed to the third argument of `window.open()`. For example, if a user did not want to use the default value of `"status=no, toolbar=no, scrollbars=yes"` and wanted to use `"toolbar=yes, resizable=yes"`, they could pass an object which would then get mapped into a string with the same format. So, the following could done:

```jsx
<ReactToPrint
    {...otherProps}
    printWindowOptions: {
        toolbar: 'yes',
        resizable: 'yes',
    }
/>
```

And would be interpreted as `"toolbar=yes, resizable=yes"` to be passed in to `window.open()`.