### PR TITLE
Support for IE11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,10 @@ class ReactToPrint extends React.Component {
     };
 
     printWindow.onload = () => {
+      /* IE11 support */
+      if ( window.navigator && window.navigator.userAgent.includes( 'Trident/7.0' ) ) { 
+          printWindow.onload = null;
+      }
 
       let domDoc = printWindow.contentDocument || printWindow.contentWindow.document;
       const srcCanvasEls = [...contentNodes.querySelectorAll('canvas')];


### PR DESCRIPTION
Hi, this should fix the IE11 issue.  when .close() was called a few lines down it was re-triggering the onload event in that browser.  Thanks for your help regarding the github process.