### PR TITLE
Handle empty href attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![dependencies Status](https://david-dm.org/gregnb/react-to-print/status.svg)](https://david-dm.org/gregnb/react-to-print)
 [![npm version](https://badge.fury.io/js/react-to-print.svg)](https://badge.fury.io/js/react-to-print)
 
-So you've created a React component but would love to give end users the ability to print out the contents of that component. This package aims to solve that by popping up a new print window with CSS styles copied over as well.  
+So you've created a React component but would love to give end users the ability to print out the contents of that component. This package aims to solve that by popping up a new print window with CSS styles copied over as well.
 
 ## Install
 
@@ -89,5 +89,10 @@ The component accepts the following props:
 |**`onBeforePrint`**|function|A callback function that triggers before print
 |**`onAfterPrint`**|function|A callback function that triggers after print
 |**`closeAfterPrint`**|boolean|Close the print window after action
-|**`pageStyle`**|string|Override default print window styling 
+|**`pageStyle`**|string|Override default print window styling
 |**`bodyClass`**|string|Optional class to pass to the print window body
+
+## FAQ
+
+**Why does `react-to-print` skip `<link rel="stylesheet" href="">` tags?**
+`<link>`s with empty `href` attributes are [INVALID HTML](https://www.w3.org/TR/html50/document-metadata.html#attr-link-href). In addition, they can cause all sorts of [undesirable behavior](https://gtmetrix.com/avoid-empty-src-or-href.html). For example, many browsers - including modern ones, when presented with `<link href="">` will attempt to load the current page. Some even attempt to load the current page's parent directory.

--- a/src/index.js
+++ b/src/index.js
@@ -75,12 +75,20 @@ class ReactToPrint extends React.Component {
     const linkNodes = document.querySelectorAll('link[rel="stylesheet"]');
 
     this.linkTotal = linkNodes.length || 0;
-    this.linkLoaded = 0;
+    this.linksLoaded = [];
+    this.linksErrored = [];
 
-    const markLoaded = (type) => {
-      this.linkLoaded++;
+    const markLoaded = (linkNode, loaded) => {
+      if (loaded) {
+        this.linksLoaded.push(linkNode);
+      } else {
+        console.error("'react-to-print' was unable to load a link. It may be invalid. 'react-to-print' will continue attempting to print the page. The link the errored was:", linkNode);
+        this.linksErrored.push(linkNode);
+      }
 
-      if (this.linkLoaded === this.linkTotal) {
+      // We may have errors, but attempt to print anyways - maybe they are trivial and the user will
+      // be ok ignoring them
+      if (this.linksLoaded.length + this.linksErrored.length === this.linkTotal) {
         this.triggerPrint(printWindow);
       }
     };
@@ -138,8 +146,8 @@ class ReactToPrint extends React.Component {
               newHeadEl.setAttribute(attr.nodeName, attr.nodeValue);
             });
 
-            newHeadEl.onload = markLoaded.bind(null, 'link');
-            newHeadEl.onerror = markLoaded.bind(null, 'link');
+            newHeadEl.onload = markLoaded.bind(null, newHeadEl, true);
+            newHeadEl.onerror = markLoaded.bind(null, newHeadEl, false);
           }
 
           domDoc.head.appendChild(newHeadEl);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import { findDOMNode } from "react-dom";
 import PropTypes from "prop-types";
 
 class ReactToPrint extends React.Component {
-
   static propTypes = {
     /** Copy styles over into print window. default: true */
     copyStyles: PropTypes.bool,
@@ -42,7 +41,6 @@ class ReactToPrint extends React.Component {
       if (onAfterPrint) {
         onAfterPrint();
       }
-
     }, 500);
   }
 
@@ -53,7 +51,6 @@ class ReactToPrint extends React.Component {
   }
 
   handlePrint = () => {
-
     const {
       bodyClass,
       content,
@@ -81,13 +78,11 @@ class ReactToPrint extends React.Component {
     this.linkLoaded = 0;
 
     const markLoaded = (type) => {
-
       this.linkLoaded++;
 
       if (this.linkLoaded === this.linkTotal) {
         this.triggerPrint(printWindow);
       }
-
     };
 
     printWindow.onload = () => {
@@ -122,16 +117,13 @@ class ReactToPrint extends React.Component {
       });
 
       if (copyStyles !== false) {
-
         const headEls = document.querySelectorAll('style, link[rel="stylesheet"]');
 
         [...headEls].forEach((node, index) => {
-
           let newHeadEl = domDoc.createElement(node.tagName);
           let styleCSS = "";
 
           if (node.tagName === 'STYLE') {
-
             if (node.sheet) {
               for (let i = 0; i < node.sheet.cssRules.length; i++) {
                 styleCSS += node.sheet.cssRules[i].cssText + "\r\n";
@@ -139,11 +131,8 @@ class ReactToPrint extends React.Component {
 
               newHeadEl.setAttribute('id', `react-to-print-${index}`);
               newHeadEl.appendChild(domDoc.createTextNode(styleCSS));
-
             }
-
           } else {
-
             let attributes = [...node.attributes];
             attributes.forEach(attr => {
               newHeadEl.setAttribute(attr.nodeName, attr.nodeValue);
@@ -151,35 +140,26 @@ class ReactToPrint extends React.Component {
 
             newHeadEl.onload = markLoaded.bind(null, 'link');
             newHeadEl.onerror = markLoaded.bind(null, 'link');
-
           }
 
           domDoc.head.appendChild(newHeadEl);
-
         });
-
-
       }
 
       if (this.linkTotal === 0 || copyStyles === false) {
         this.triggerPrint(printWindow);
       }
-
     };
 
     document.body.appendChild(printWindow);
-
   }
 
   render() {
-
     return React.cloneElement(this.props.trigger(), {
       ref: (el) => this.triggerRef = el,
       onClick: this.handlePrint
     });
-
   }
-
 }
 
 export default ReactToPrint;


### PR DESCRIPTION
This fixes #58 

`<link>` tags with empty `href` attributes are [INVALID HTML](https://www.w3.org/TR/html50/document-metadata.html#attr-link-href). Further, browsers often do [unexpected things](https://gtmetrix.com/avoid-empty-src-or-href.html) when they encounter an empty `href`. For example, some will attempt to load the current page. Some will event attempt to load the current page's parent directory. (My current browser, Chrome 70, attempts to load the current page.)

To solve these problems, this PR causes `react-to-print` to skip loading `<link>` tags when they have an empty `href` attribute.

This PR also actually makes use of the `markLoaded` method's parameters (I changed them up a bit), and it removes some unneeded whitespace.

Testing strategy:

1. Open the test page at `http://0.0.0.0:5060/#` after running `npm run webpack-dev-server`
2. Test that everything works normally (there are no malformed links on the test page)
3. In console, do:
    1. `h = document.getElementsByTagName('head')`
    2. `h[0].innerHTML = h[0].innerHTML + '<link type="text/css" id="dark-mode" rel="stylesheet" href="">';`
4. Click "Print this out!"