### PR TITLE
Don't include /example in published npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+example/


### PR DESCRIPTION
`/example` is code for development and is not needed by end users. This saves users from having to download code they will not use.