### PR TITLE
Remove `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-example/


### PR DESCRIPTION
This reverts #72 

I didn't realize this library already specifies the `files` attribute in its `package.json` file, which acts as a whitelist for `npm pack/publish` so we don't need to create a blacklist with a `.npmignore` file.

I made the initial commit in #72 because I had seen a bug post about it to another package I manage and for some reason made the change here instead of there - SORRY!