### PR TITLE
Fix imports and exports for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
 
 /*~ This declaration specifies that the class constructor function
  *~ is the exported object from the file
  */
-export = ReactToPrint;
+export default ReactToPrint;
 
 declare class ReactToPrint extends React.Component<ReactToPrint.ReactToPrintProps> {
   static propTypes: {


### PR DESCRIPTION
`react-to-print` is causing failing build in project using TypeScript. The reason are 1) incorrect imports for `React` and `PropTypes` and 2) `ReactToPrint` not exported as default.

Errors:
```
Failed to compile.

C:\temp\node_modules\react-to-print\lib\index.d.ts
(1,8): error TS1192: Module '"C:/temp/node_modules/@types/react/index"' has no default export.
```

```
Failed to compile.

C:\temp\node_modules\react-to-print\lib\index.d.ts
(2,8): error TS1192: Module '"C:/temp/node_modules/@types/prop-types/index"' has no default export.
```

```
Failed to compile.

./src/Foobar.tsx
(14,8): error TS1192: Module '"C:/temp/node_modules/react-to-print/lib/index"' has no default export.
```