### PR TITLE
Update IE11 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ class ReactToPrint extends React.Component {
       }
 
       const canvasEls = domDoc.querySelectorAll('canvas');
-      [...canvasEls].forEach((node, index) => {
+      Array.prototype.forEach.call(canvasEls, (node, index) => {
         node.getContext('2d').drawImage(srcCanvasEls[index], 0, 0);
       });
 


### PR DESCRIPTION
NodeList object spreading is not supported in IE11.