### PR TITLE
Fix for loading fonts

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
     removeWindow = (target) => {
         setTimeout(() => {
             target.parentNode.removeChild(target);
-        }, 0);
+        }, 500);
     };
 
     triggerPrint = (target) => {
@@ -50,7 +50,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
             if (onAfterPrint) {
                 onAfterPrint();
             }
-        }, 0);
+        }, 500);
     };
 
     handlePrint = () => {


### PR DESCRIPTION
Fix for #118.
Before the rewrite to typescript, the triggerPrint settimout had a 500 milliseconds delay, which gave the browser enough time to load the fonts. 
In the new version, the delay was 0 milliseconds, and that's why the fonts weren't  loaded.