### PR TITLE
Fix issue #64: Print dialogue only open once in safari on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.1.3 (May 22nd, 2019)
+
+- FIX [64](https://github.com/gregnb/react-to-print/issues/64): Print dialogue only open once in safari on Mac
+
 ## 2.1.2 (May 3rd, 2019)
 
 - FIX [118](https://github.com/gregnb/react-to-print/issues/118): Ensure fonts have time to load before printing, thanks [aviklai](https://github.com/aviklai)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-to-print",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Print React components in the browser",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,12 +29,6 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
     linksLoaded: Element[];
     linksErrored: Element[];
 
-    removeWindow = (target) => {
-        setTimeout(() => {
-            target.parentNode.removeChild(target);
-        }, 500);
-    };
-
     triggerPrint = (target) => {
         const { onBeforePrint, onAfterPrint } = this.props;
 
@@ -45,7 +39,6 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
         setTimeout(() => {
             target.contentWindow.focus();
             target.contentWindow.print();
-            this.removeWindow(target);
 
             if (onAfterPrint) {
                 onAfterPrint();


### PR DESCRIPTION
Removed removeWindow method. Tested on example and custom app, seems to work fine on Chrome, Firefox and Safari.

Updated version on package.json and Changelog file.