### PR TITLE
Added removeAfterPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The component accepts the following props:
 |   **`copyStyles`**    | boolean  | Copies all &lt;style> and &lt;link type="stylesheet" /> from <head> inside the parent window into the print window. (default: true) |
 |  **`onBeforePrint`**  | function | A callback function that triggers before print. Either returns void or a Promise. If the function returns a Promise the content will be printed when the Promise is resolved. Users are responsible for catching the Promise rejecting.                                                                                     |
 |  **`onAfterPrint`**   | function | A callback function that triggers after print                                                                                       |
-| **`closeAfterPrint`** | boolean  | Close the print window after action                                                                                                 |
+| **`removeAfterPrint`** | boolean  | Remove the print iframe after action                                                                                                 |
 |    **`pageStyle`**    | string   | Override default print window styling                                                                                               |
 |    **`bodyClass`**    | string   | Optional class to pass to the print window body                                                                                     |
 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -22,6 +22,7 @@ class Example extends React.Component {
                     content={this.renderContent}
                     onBeforePrint={this.handleBeforePrint}
                     onAfterPrint={this.handleAfterPrint}
+                    removeAfterPrint
                 />
                 <ComponentToPrint ref={this.setRef}/>
             </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,8 @@ export interface IReactToPrintProps {
     pageStyle?: string;
     /** Optional class to pass to the print window body */
     bodyClass?: string;
+     /** Optional - remove the iframe after printing.*/
+    removeAfterPrint?: boolean
 }
 
 export default class ReactToPrint extends React.Component<IReactToPrintProps> {
@@ -32,10 +34,12 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
     startPrint = (target, onAfterPrint) => {
         setTimeout(() => {
             target.contentWindow.focus();
-            target.contentWindow.print();
-            
+            target.contentWindow.print();            
             if (onAfterPrint) {
                 onAfterPrint();
+            }
+            if (this.props.removeAfterPrint) {
+                target.remove();
             }
         }, 500);
     }


### PR DESCRIPTION
#151

I looked at the commits of the past year and I saw that the closeAfterPrint property was used when the printing was done using a window and not an iframe.
Since currently the library uses iframe for printing, I added a removeAfterPrint property which removes the iframe after printing.
For now, it defaults to false since by default the iframe was not removed and I don't want it to add a breaking change (maybe someone used the iframe after the print)