### PR TITLE
Revamp linting, fix bug found from linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-dist/
-lib/
-node_modules/

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -136,9 +136,9 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
             }
 
             const canvasEls = domDoc.querySelectorAll("canvas");
-            for (let index = 0, l = canvasEls.length; index < l; ++index) {
-                const node = canvasEls[index];
-                node.getContext("2d").drawImage(srcCanvasEls[index] as HTMLCanvasElement, 0, 0);
+            for (let i = 0, canvasElsLen = canvasEls.length; i < canvasElsLen; ++i) {
+                const node = canvasEls[i];
+                node.getContext("2d").drawImage(srcCanvasEls[i] as HTMLCanvasElement, 0, 0);
             }
 
             if (copyStyles !== false) {
@@ -153,7 +153,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                         if (sheet) {
                             let styleCSS = "";
                             // NOTE: for-of is not supported by IE
-                            for (let j = 0, cssLen = sheet.cssRules.length; j < cssLen; j++) {
+                            for (let j = 0, cssLen = sheet.cssRules.length; j < cssLen; ++j) {
                                 if (typeof sheet.cssRules[j].cssText === "string") {
                                     styleCSS += `${sheet.cssRules[j].cssText}\r\n`;
                                 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,13 @@
     "declaration": true,
     "removeComments": true,
     "downlevelIteration": true,
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": [
     "./src",
   ],
   "exclude": [
+    "dist",
     "lib"
   ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "tslint:recommended",
+  "rules": {
+    "max-line-length": [true, {
+      "limit": 100
+    }],
+    "prefer-for-of": false
+  }
+}


### PR DESCRIPTION
This fixes our linting such that `npm run lint` now works, and from that it fixes a bug that was found with linting working:

When we encountered a link that was not a STYLE tag and that had an `href` value, we would override the loop going through all the stylesheets with an inner loop, possibly causing us to miss some style sheets or to attempt to access stylesheets that did did not exist on the page.