### PR TITLE
Version 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.6.0 (March 3rd, 2020)
+
+- FEATURE [220](https://github.com/gregnb/react-to-print/pull/220) Adds a `suppressErrors` prop. When passed, console logging of errors is disabled. Thanks [invious](https://github.com/invious)
+
 ## 2.5.1 (January 9th, 2020)
 
 - CHORE [208](https://github.com/gregnb/react-to-print/pull/208) Minor improvements to code comments, linting, and README

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-to-print",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-to-print",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Print React components in the browser",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -24,6 +24,7 @@
     "react-to-print"
   ],
   "author": "gregnb <gregnb@gmail.com>",
+  "contributors": ["Matthew Herbst"],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gregnb/react-to-print/issues"


### PR DESCRIPTION
Adds a `suppressErrors` prop. When passed, console logging of errors is disabled.