### PR TITLE
Edge is duplicating images

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The component accepts the following props (note: `?` denotes an optional prop):
 |    **`pageStyle`**    | `string?`   | Override default print window styling                                                                                               |
 |    **`bodyClass`**    | `string?`   | Class to pass to the print window body                                                                                     |
 |    **`suppressErrors`**    | `boolean?`   | When passed, prevents console logging of errors                                                                                     |
+|    **`excludeImgHeader`**    | `boolean?`   | When passed, exclude images from the header                                                                                   |
 
 ## FAQ
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,8 @@ export interface IReactToPrintProps {
     removeAfterPrint?: boolean;
     /** Optional - suppress error messages */
     suppressErrors?: boolean;
+    /** Optional - If browser (Ex. Edge) duplicates images you can remove them from the header */
+    excludeImgHeader?: boolean;
 }
 
 export default class ReactToPrint extends React.Component<IReactToPrintProps> {
@@ -113,6 +115,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
             copyStyles = true,
             pageStyle,
             suppressErrors,
+            excludeImgHeader = false
         } = this.props;
 
         const contentEl = content();
@@ -139,7 +142,11 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
         printWindow.title = "Print Window";
 
         const contentNodes = findDOMNode(contentEl);
-        const linkNodes = document.querySelectorAll("link[rel='stylesheet'], img");
+        const linkNodesWhitelist = ["ink[rel='stylesheet']"];
+        if(!excludeImgHeader) {
+           linkNodesWhitelist.push("img");
+        }
+        const linkNodes = document.querySelectorAll(linkNodesWhitelist.length === 1 ? linkNodesWhitelist : linkNodesWhitelist.join(", "));
 
         this.linkTotal = linkNodes.length || 0;
         this.linksLoaded = [];
@@ -163,6 +170,10 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
         };
 
         printWindow.onload = () => {
+            const {
+                excludeImgHeader = false
+            } = this.props;
+            
             /* IE11 support */
             if (window.navigator && window.navigator.userAgent.indexOf("Trident/7.0") > -1) {
                 printWindow.onload = null;
@@ -198,7 +209,11 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                 }
 
                 if (copyStyles !== false) {
-                    const headEls = document.querySelectorAll("style, link[rel='stylesheet'], img");
+                    const headElsWhitelist = ["style", "ink[rel='stylesheet']"];
+                    if(!excludeImgHeader) {
+                       headElsWhitelist.push("img");
+                    }
+                    const headEls = document.querySelectorAll(headElsWhitelist.join(", "));
 
                     for (let i = 0, headElsLen = headEls.length; i < headElsLen; ++i) {
                         const node = headEls[i];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -142,7 +142,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
         printWindow.title = "Print Window";
 
         const contentNodes = findDOMNode(contentEl);
-        const linkNodesWhitelist = ["ink[rel='stylesheet']"];
+        const linkNodesWhitelist = ["link[rel='stylesheet']"];
         if(!excludeImgHeader) {
            linkNodesWhitelist.push("img");
         }
@@ -209,7 +209,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                 }
 
                 if (copyStyles !== false) {
-                    const headElsWhitelist = ["style", "ink[rel='stylesheet']"];
+                    const headElsWhitelist = ["style", "link[rel='stylesheet']"];
                     if(!excludeImgHeader) {
                        headElsWhitelist.push("img");
                     }


### PR DESCRIPTION
Let's' have as an option to remove the images in the header since Edge browser is duplicating the images when it attempts to print. I'm not sure if in other browsers images are required in the header but this works pretty well so far in Firefox, Chrome, and Edge on desktop.

Fixes [218](https://github.com/gregnb/react-to-print/issues/218)