### PR TITLE
Feature/ new documentTitle props to set filename for pdf print

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The component accepts the following props:
 |     **`trigger`**     | `function` | A function that returns a React Component or HTML element                                                                           |
 |     **`content`**     | `function` | A function that returns a component reference value. The content of this reference value is then used for print                     |
 |   **`copyStyles?`**    | `boolean`  | Copy all `<style>` and `<link type="stylesheet" />` tags from `<head>` inside the parent window into the print window. (default: `true`) |
+|     **`documentTitle?`**     | `string` | Optional default title for document if saved as file
 | **`onBeforeGetContent?`** | `function` | Callback function that triggers before the library gathers the page's content. Either returns void or a Promise. This can be used to change the content on the page before printing.
 |  **`onBeforePrint?`**  | `function` | Callback function that triggers before print. Either returns void or a Promise. Note: this function is run immediately prior to printing, but after the page's content has been gathered. To modify content before printing, use `onBeforeGetContent` instead.                                                                                     |
 |  **`onAfterPrint?`**   | `function` | Callback function that triggers after print                                                                                       |

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -38,6 +38,7 @@ class Example extends React.Component<{}, State> {
             <div>
                 {this.state.isLoading && <p className="indicator">Loading...</p>}
                 <ReactToPrint
+                    documentTitle={"Awesome_FileName"}
                     trigger={this.renderTrigger}
                     content={this.renderContent}
                     onBeforeGetContent={this.onBeforeGetContent}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,8 @@ export interface ITriggerProps<T> {
 type PropertyFunction<T> = () => T;
 
 export interface IReactToPrintProps {
+    /** Optional title for document if saved as file */
+    documentTitle?: string
     /** Class to pass to the print window body */
     bodyClass?: string;
     /** Content to be printed */
@@ -50,6 +52,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
             onAfterPrint,
             removeAfterPrint,
             suppressErrors,
+            documentTitle,
         } = this.props;
 
         setTimeout(() => {
@@ -59,7 +62,19 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                 // Some browsers, such as Firefox Android, do not support printing at all
                 // https://developer.mozilla.org/en-US/docs/Web/API/Window/print
                 if (target.contentWindow.print) {
+
+                    // save current document title before override
+                    const tempTitle = document.title;
+                    if (documentTitle) {
+                        document.title  = documentTitle; // It causes overriding tab title during the print process
+                    }
+
                     target.contentWindow.print();
+
+                    // reset document title with original title after print process
+                    if (documentTitle) {
+                        document.title = tempTitle;
+                    }
 
                     if (onAfterPrint) {
                         onAfterPrint();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,14 +9,14 @@ export interface ITriggerProps<T> {
 type PropertyFunction<T> = () => T;
 
 export interface IReactToPrintProps {
-    /** Optional title for document if saved as file */
-    documentTitle?: string
     /** Class to pass to the print window body */
     bodyClass?: string;
     /** Content to be printed */
     content: () => React.ReactInstance | null;
     /** Copy styles over into print window. default: true */
     copyStyles?: boolean;
+    /** Optional title for document if saved as file */
+    documentTitle?: string
     /** Callback function to trigger after print */
     onAfterPrint?: () => void;
     /** Callback function to trigger before page content is retrieved for printing */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,7 +66,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                     // save current document title before override
                     const tempTitle = document.title;
                     if (documentTitle) {
-                        document.title  = documentTitle; // It causes overriding tab title during the print process
+                        document.title  = documentTitle; // Overrides the tab title during the print process
                     }
 
                     target.contentWindow.print();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,7 +63,6 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                 // https://developer.mozilla.org/en-US/docs/Web/API/Window/print
                 if (target.contentWindow.print) {
 
-                    // save current document title before override
                     const tempTitle = document.title;
                     if (documentTitle) {
                         document.title  = documentTitle; // Overrides the tab title during the print process

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,6 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
 
                     target.contentWindow.print();
 
-                    // reset document title with original title after print process
                     if (documentTitle) {
                         document.title = tempTitle;
                     }


### PR DESCRIPTION
Here a PR to add ability to set custom filename when print to pdf file with a new props documentTitle.
It causes a temporary override of the document.title (no other way to do this, print api does not provide a way to ) and reset it after print.

Fixes #243 