### PR TITLE
Examples overhaul, hook default props fix, always clear `onload` event listener

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/README.md
+++ b/README.md
@@ -262,3 +262,7 @@ If you've created a component that is intended only for printing and should not 
 ```
 
 This will hide `ComponentToPrint` but keep it in the DOM so that it can be copied for printing.
+
+### Changing print settings in the print dialog
+
+Unfortunately there is no standard browser API for interacting with the print dialog. All `react-to-print` is able to do is open the dialog and give it the desired content to print. We cannot modify settings such as the default paper size, if the user has background graphics selected or not, etc.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The component accepts the following props:
 |     **`documentTitle?`**     | `string` | Set the title for printing when saving as a file
 | **`onBeforeGetContent?`** | `function` | Callback function that triggers before the library gathers the page's content. Either returns void or a Promise. This can be used to change the content on the page before printing.
 |  **`onBeforePrint?`**  | `function` | Callback function that triggers before print. Either returns void or a Promise. Note: this function is run immediately prior to printing, but after the page's content has been gathered. To modify content before printing, use `onBeforeGetContent` instead.                                                                                     |
-|  **`onAfterPrint?`**   | `function` | Callback function that triggers after print                                                                                       |
+|  **`onAfterPrint?`**   | `function` | Callback function that triggers after the print dialog is closed regardless of if the user selected to print or cancel                                                                                      |
 |  **`onPrintError?`**   | `function` | Callback function (signature: `function(errorLocation: 'onBeforePrint' | 'onBeforeGetContent', error: Error)`) that will be called if there is a printing error serious enough that printing cannot continue. Currently limited to Promise rejections in `onBeforeGetContent` or `onBeforePrint`. Use this to attempt to print again. `errorLocation` will tell you in which callback the Promise was rejected.                                                                                     |
 | **`removeAfterPrint?`** | `boolean`  | Remove the print iframe after action. Defaults to `false`.                                                                                                 |
 |    **`pageStyle?`**    | `string | function`   | We set some basic styles to help improve page printing. Use this to override them and provide your own. If given as a function, it must return a `string`                                                                                               |
@@ -142,7 +142,7 @@ class Example extends React.Component {
         <ReactToPrint content={() => this.componentRef}>
           <PrintContextConsumer>
             {({ handlePrint }) => (
-                <button onClick={handlePrint}>Print this out!</button>
+              <button onClick={handlePrint}>Print this out!</button>
             )}
           </PrintContextConsumer>
         </ReactToPrint>

--- a/example/ClassComponent/index.tsx
+++ b/example/ClassComponent/index.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+
+import { ComponentToPrint } from "../ComponentToPrint";
+import ReactToPrint from "../../src/index";
+
+export class ClassComponent extends React.PureComponent<{}, { isLoading: boolean, text: string }> {
+  componentRef: ComponentToPrint | null = null;
+
+  constructor(props: Readonly<{}>) {
+    super(props);
+
+    this.state = {
+      isLoading: false,
+      text: "old boring text",
+    };
+  }
+
+  handleAfterPrint = () => {
+    console.log("`onAfterPrint` called"); // tslint:disable-line no-console
+  }
+
+  handleBeforePrint = () => {
+    console.log("`onBeforePrint` called"); // tslint:disable-line no-console
+  }
+
+  handleOnBeforeGetContent = () => {
+    console.log("`onBeforeGetContent` called"); // tslint:disable-line no-console
+    this.setState({ text: "Loading new text...", isLoading: true });
+
+    return new Promise((resolve: any) => {
+      setTimeout(() => {
+        this.setState({ text: "New, Updated Text!", isLoading: false }, resolve);
+      }, 2000);
+    });
+  };
+
+  setComponentRef = (ref: ComponentToPrint) => {
+    this.componentRef = ref;
+  }
+
+  reactToPrintContent = () => {
+    return this.componentRef;
+  }
+
+  reactToPrintTrigger = () => {
+    // NOTE: could just as easily return <SomeComponent />. Do NOT pass an `onClick` prop
+    // to the root node of the returned component as it will be overwritten.
+
+    // Bad: the `onClick` here will be overwritten by `react-to-print`
+    // return <a href="#" onClick={() => alert('This will not work')}>Print this out!</a>;
+
+    // Good
+    return <a href="#">Print using a Class Component</a>;
+  }
+
+  render() {
+    return (
+      <div>
+        <ReactToPrint
+          content={this.reactToPrintContent}
+          documentTitle="AwesomeFileName"
+          onAfterPrint={this.handleAfterPrint}
+          onBeforeGetContent={this.handleOnBeforeGetContent}
+          onBeforePrint={this.handleBeforePrint}
+          removeAfterPrint
+          trigger={this.reactToPrintTrigger}
+        />
+        {this.state.isLoading && <p className="indicator">Loading...</p>}
+        <ComponentToPrint ref={this.setComponentRef} text={this.state.text} />
+      </div>
+    );
+  }
+}

--- a/example/ClassComponentContextConsumer/index.tsx
+++ b/example/ClassComponentContextConsumer/index.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+
+import { ComponentToPrint } from "../ComponentToPrint";
+import ReactToPrint, { PrintContextConsumer } from "../../src/index";
+
+export class ClassComponentContextConsumer extends React.PureComponent<{}, { isLoading: boolean, text: string }> { // tslint:disable-line max-line-length
+  componentRef: ComponentToPrint | null = null;
+
+  constructor(props: Readonly<{}>) {
+    super(props);
+
+    this.state = {
+      isLoading: false,
+      text: "old boring text",
+    };
+  }
+
+  handleAfterPrint = () => {
+    console.log("`onAfterPrint` called"); // tslint:disable-line no-console
+  }
+
+  handleBeforePrint = () => {
+    console.log("`onBeforePrint` called"); // tslint:disable-line no-console
+  }
+
+  handleOnBeforeGetContent = () => {
+    console.log("`onBeforeGetContent` called"); // tslint:disable-line no-console
+    this.setState({ text: "Loading new text...", isLoading: true });
+
+    return new Promise((resolve: any) => {
+      setTimeout(() => {
+        this.setState({ text: "New, Updated Text!", isLoading: false }, resolve);
+      }, 2000);
+    });
+  };
+
+  setComponentRef = (ref: ComponentToPrint) => {
+    this.componentRef = ref;
+  }
+
+  reactToPrintContent = () => {
+    return this.componentRef;
+  }
+
+  render() {
+    return (
+      <div>
+        <ReactToPrint
+          content={this.reactToPrintContent}
+          documentTitle="AwesomeFileName"
+          onAfterPrint={this.handleAfterPrint}
+          onBeforeGetContent={this.handleOnBeforeGetContent}
+          onBeforePrint={this.handleBeforePrint}
+          removeAfterPrint
+        >
+          <PrintContextConsumer>
+            {({ handlePrint }) => (
+              <button onClick={handlePrint}>
+                Print using a Class Component with PrintContextConsumer
+              </button>
+            )}
+          </PrintContextConsumer>
+        </ReactToPrint>
+        {this.state.isLoading && <p className="indicator">Loading...</p>}
+        <ComponentToPrint ref={this.setComponentRef} text={this.state.text} />
+      </div>
+    );
+  }
+}

--- a/example/ComponentToPrint/index.tsx
+++ b/example/ComponentToPrint/index.tsx
@@ -1,79 +1,78 @@
 import * as React from "react";
 
 type Props = { // tslint:disable-line interface-over-type-literal
-    text: string,
+  text: string,
 };
 
-export default class ComponentToPrint extends React.Component<Props> {
-    private canvasEl!: HTMLCanvasElement;
+export class ComponentToPrint extends React.PureComponent<Props> {
+  private canvasEl!: HTMLCanvasElement;
 
-    public componentDidMount() {
-        const ctx = this.canvasEl.getContext("2d");
-        if (ctx) {
-            ctx.beginPath();
-            ctx.arc(95, 50, 40, 0, 2 * Math.PI);
-            ctx.stroke();
-        }
+  public componentDidMount() {
+    const ctx = this.canvasEl.getContext("2d");
+    if (ctx) {
+      ctx.beginPath();
+      ctx.arc(95, 50, 40, 0, 2 * Math.PI);
+      ctx.stroke();
     }
+  }
 
-    private setRef = (ref: HTMLCanvasElement) => this.canvasEl = ref;
+  private setRef = (ref: HTMLCanvasElement) => this.canvasEl = ref;
 
-    public render() {
-        return (
-            <div className="relativeCSS">
-                <div className="flash"/>
-                <img src="example/test_image.png" alt="test"/>
-                <table className="testclass">
-                    <thead>
-                    <tr>
-                        <th style={{ color: "#FF0000" }}>Column One</th>
-                        <th className="testth">Column Two</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr>
-                        <td>{this.props.text}</td>
-                        <td>2</td>
-                    </tr>
-                    <tr>
-                        <td>3</td>
-                        <td>4</td>
-                    </tr>
-                    <tr>
-                        <td>5</td>
-                        <td><img
-                            src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
-                            width="50" alt="Google logo"/></td>
-                    </tr>
-                    <tr>
-                        <td>svg</td>
-                        <td>
-                            <svg width="100" height="100">
-                                <circle cx="50" cy="50" r="40" stroke="green" strokeWidth="4" fill="yellow"/>
-                            </svg>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>canvas</td>
-                        <td>
-                            <canvas id="myCanvas" ref={this.setRef} width="200" height="100">
-                                Your browser does not support the HTML5 canvas tag.
-                            </canvas>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-                <div className="container">
-                    <div>
-                        <span>Image 01</span>
-                        <img src="https://free-images.com/or/a31c/swan_flying_bird_fly.jpg" alt="Free-Images.com" width="100%"/>
-                    </div>
-                    <div>
-                        <span>Image 02</span>
-                        <img src="https://free-images.com/or/176d/squirrel_tail_bushy_tail.jpg" alt="Free-Images.com" width="100%"/>
-                    </div>
-                </div>
+  public render() {
+    return (
+      <div className="relativeCSS">
+        <div className="flash" />
+        <img alt="A test image" src="example/test_image.png" />
+        <table className="testclass">
+          <thead>
+          <tr>
+            <th style={{ color: "#FF0000" }}>Column One</th>
+            <th className="testth">Column Two</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>{this.props.text}</td>
+            <td>2</td>
+          </tr>
+          <tr>
+            <td>3</td>
+            <td>4</td>
+          </tr>
+          <tr>
+            <td>5</td>
+            <td>
+              <img
+                alt="Google logo"
+                src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
+                width="50"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>svg</td>
+            <td>
+              <svg height="100" width="100">
+                <circle cx="50" cy="50" fill="yellow" r="40" stroke="green" strokeWidth="4" />
+              </svg>
+            </td>
+          </tr>
+          <tr>
+            <td>canvas</td>
+            <td>
+              <canvas height="100" id="myCanvas" ref={this.setRef} width="200">
+                Your browser does not support the HTML5 canvas tag.
+              </canvas>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+          <div className="container">
+            <div>
+              <img alt="Swan" src="https://free-images.com/or/a31c/swan_flying_bird_fly.jpg" width="300px"/>
             </div>
-        );
-    }
+          </div>
+      </div>
+    );
+  }
 }

--- a/example/FunctionalComponent/index.tsx
+++ b/example/FunctionalComponent/index.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+
+import { ComponentToPrint } from "../ComponentToPrint";
+import ReactToPrint from "../../src/index";
+
+export const FunctionalComponent = () => {
+  const componentRef = React.useRef(null);
+
+  // TODO: want to make this `null` default but TS complains
+  const onBeforeGetContentResolve = React.useRef(Promise.resolve);
+
+  const [loading, setLoading] = React.useState(false);
+  const [text, setText] = React.useState("old boring text");
+
+  const handleAfterPrint = React.useCallback(() => {
+    console.log("`onAfterPrint` called"); // tslint:disable-line no-console
+  }, []);
+
+  const handleBeforePrint = React.useCallback(() => {
+    console.log("`onBeforePrint` called"); // tslint:disable-line no-console
+  }, []);
+
+  const handleOnBeforeGetContent = React.useCallback(() => {
+    console.log("`onBeforeGetContent` called"); // tslint:disable-line no-console
+    setLoading(true);
+    setText("Loading new text...");
+
+    return new Promise((resolve: any) => {
+      onBeforeGetContentResolve.current = resolve;
+
+      setTimeout(() => {
+        setLoading(false);
+        setText("New, Updated Text!");
+        resolve();
+      }, 2000);
+    });
+  }, [setLoading, setText]);
+
+  React.useEffect(() => {
+    if (text === "New, Updated Text!" && typeof onBeforeGetContentResolve.current === "function") {
+      onBeforeGetContentResolve.current();
+    }
+  }, [onBeforeGetContentResolve.current, text]);
+
+  const reactToPrintContent = React.useCallback(() => {
+    return componentRef.current;
+  }, [componentRef.current]);
+
+  const reactToPrintTrigger = React.useCallback(() => {
+    // NOTE: could just as easily return <SomeComponent />. Do NOT pass an `onClick` prop
+    // to the root node of the returned component as it will be overwritten.
+
+    // Bad: the `onClick` here will be overwritten by `react-to-print`
+    // return <a href="#" onClick={() => alert('This will not work')}>Print this out!</a>;
+
+    // Good
+    return <a href="#">Print using a Functional Component</a>;
+  }, []);
+
+  return (
+    <div>
+      <ReactToPrint
+        content={reactToPrintContent}
+        documentTitle="AwesomeFileName"
+        onAfterPrint={handleAfterPrint}
+        onBeforeGetContent={handleOnBeforeGetContent}
+        onBeforePrint={handleBeforePrint}
+        removeAfterPrint
+        trigger={reactToPrintTrigger}
+      />
+      {loading && <p className="indicator">Loading...</p>}
+      <ComponentToPrint ref={componentRef} text={text} />
+    </div>
+  );
+};

--- a/example/FunctionalComponentWithHook/index.tsx
+++ b/example/FunctionalComponentWithHook/index.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+
+import { ComponentToPrint } from "../ComponentToPrint";
+import { useReactToPrint } from "../../src/index";
+
+export const FunctionalComponentWithHook = () => {
+  const componentRef = React.useRef(null);
+
+  // TODO: want to make this `null` default but TS complains
+  const onBeforeGetContentResolve = React.useRef(Promise.resolve);
+
+  const [loading, setLoading] = React.useState(false);
+  const [text, setText] = React.useState("old boring text");
+
+  const handleAfterPrint = React.useCallback(() => {
+    console.log("`onAfterPrint` called"); // tslint:disable-line no-console
+  }, []);
+
+  const handleBeforePrint = React.useCallback(() => {
+    console.log("`onBeforePrint` called"); // tslint:disable-line no-console
+  }, []);
+
+  const handleOnBeforeGetContent = React.useCallback(() => {
+    console.log("`onBeforeGetContent` called"); // tslint:disable-line no-console
+    setLoading(true);
+    setText("Loading new text...");
+
+    return new Promise((resolve: any) => {
+      onBeforeGetContentResolve.current = resolve;
+
+      setTimeout(() => {
+        setLoading(false);
+        setText("New, Updated Text!");
+        resolve();
+      }, 2000);
+    });
+  }, [setLoading, setText]);
+
+  const reactToPrintContent = React.useCallback(() => {
+    return componentRef.current;
+  }, [componentRef.current]);
+
+  const handlePrint = useReactToPrint({
+    content: reactToPrintContent,
+    documentTitle: "AwesomeFileName",
+    onBeforeGetContent: handleOnBeforeGetContent,
+    onBeforePrint: handleBeforePrint,
+    onAfterPrint: handleAfterPrint,
+    removeAfterPrint: true,
+  });
+
+  React.useEffect(() => {
+    if (text === "New, Updated Text!" && typeof onBeforeGetContentResolve.current === "function") {
+      onBeforeGetContentResolve.current();
+    }
+  }, [onBeforeGetContentResolve.current, text]);
+
+  return (
+    <div>
+      {loading && <p className="indicator">Loading...</p>}
+      <button onClick={handlePrint}>Print this out!</button>
+      <ComponentToPrint ref={componentRef} text={text} />
+    </div>
+  );
+};

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,55 +1,28 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import ReactToPrint from "../src/index";
-import ComponentToPrint from "./ComponentToPrint";
+import { ClassComponent } from "./ClassComponent";
+import { ClassComponentContextConsumer } from "./ClassComponentContextConsumer";
+import { FunctionalComponent } from "./FunctionalComponent";
+import { FunctionalComponentWithHook } from "./FunctionalComponentWithHook";
 import "./relativecss/test.css";
 
 interface State {
-    text: string;
-    isLoading: boolean;
+  text: string;
+  isLoading: boolean;
 }
 
 class Example extends React.Component<{}, State> {
-    private componentRef!: ComponentToPrint;
-
-    constructor(props: Readonly<{}>) {
-        super(props);
-        this.state = {
-            text: "000000000",
-            isLoading: false
-        };
-    }
-
-    private handleAfterPrint = () => console.log("after print!"); // tslint:disable-line no-console
-    private handleBeforePrint = () => this.setState({ isLoading: false});
-    private renderContent = () => this.componentRef;
-    private renderTrigger = () => <button type="button">Print this out!</button>;
-    private onBeforeGetContent = () => {
-        return new Promise((resolve: any) =>
-            this.setState({ text: "text changed", isLoading: true }, resolve)
-        );
-    };
-
-    setRef = (ref: ComponentToPrint) => this.componentRef = ref;
-
-    render() {
-        return (
-            <div>
-                {this.state.isLoading && <p className="indicator">Loading...</p>}
-                <ReactToPrint
-                    documentTitle={"Awesome_FileName"}
-                    trigger={this.renderTrigger}
-                    content={this.renderContent}
-                    onBeforeGetContent={this.onBeforeGetContent}
-                    onBeforePrint={this.handleBeforePrint}
-                    onAfterPrint={this.handleAfterPrint}
-                    removeAfterPrint
-                />
-                <ComponentToPrint ref={this.setRef} text={this.state.text}/>
-            </div>
-        );
-    }
+  render() {
+    return (
+      <>
+        <ClassComponent />
+        <ClassComponentContextConsumer />
+        <FunctionalComponent />
+        <FunctionalComponentWithHook />
+      </>
+    );
+  }
 }
 
 ReactDOM.render(<Example/>, document.getElementById("app-root"));

--- a/example/relativecss/test.css
+++ b/example/relativecss/test.css
@@ -7,9 +7,6 @@
 }
 
 .indicator {
-  position: fixed;
-  left: 50%;
-  transform: translateX(-50%);
   font-size: 2rem;
   color: #FF0000;
   font-weight: 700;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,13 @@ export interface ITriggerProps<T> {
 
 type PropertyFunction<T> = () => T;
 
+const defaultProps = {
+    copyStyles: true,
+    pageStyle: "@page { size: auto;  margin: 0mm; } @media print { body { -webkit-print-color-adjust: exact; } }", // remove date/time from top
+    removeAfterPrint: false,
+    suppressErrors: false,
+};
+
 export interface IReactToPrintProps {
     /** Class to pass to the print window body */
     bodyClass?: string;
@@ -49,12 +56,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
     private linksLoaded!: Element[];
     private linksErrored!: Element[];
 
-    static defaultProps = {
-        copyStyles: true,
-        pageStyle: "@page { size: auto;  margin: 0mm; } @media print { body { -webkit-print-color-adjust: exact; } }", // remove date/time from top
-        removeAfterPrint: false,
-        suppressErrors: false,
-    };
+    static defaultProps = defaultProps;
 
     public startPrint = (target: HTMLIFrameElement) => {
         const {
@@ -374,12 +376,17 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
 
 export const useReactToPrint = hooksEnabled ?
     (props: IReactToPrintProps) => {
-        const entity = React.useMemo(() => new ReactToPrint(props), [props]);
+        const entity = React.useMemo(
+            // TODO: is there a better way of applying the defaultProps?
+            () => new ReactToPrint({ ...defaultProps, ...props }),
+            [props]
+        );
+
         return React.useCallback(() => entity.handleClick(), [entity]);
     } :
     (props: IReactToPrintProps) => {
         if (!props.suppressErrors) {
             console.warn('"react-to-print" requires React ^16.8.0 to be able to use "useReactToPrint"'); // tslint:disable-line no-console
         }
-        return null;
+        return undefined;
     };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -226,10 +226,9 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
         };
 
         printWindow.onload = () => {
-            /* IE11 support */
-            if (window.navigator && window.navigator.userAgent.indexOf("Trident/7.0") > -1) {
-                printWindow.onload = null;
-            }
+            // Some agents, such as IE11 and Enzyme (as of 2 Jun 2020) continuously call the
+            // `onload` callback. This ensures that it is only called once.
+            printWindow.onload = null;
 
             const domDoc = printWindow.contentDocument || printWindow.contentWindow?.document;
             const srcCanvasEls = (contentNodes as HTMLCanvasElement).querySelectorAll("canvas");


### PR DESCRIPTION
- Overhauled our local examples so that every use case is covered. This will improve testing and hopefully serve as additional documentation
- https://github.com/gregnb/react-to-print/issues/11#issuecomment-635901473 Fixed an issue where the `useReactToPrint` hook was not properly setting `defaultProps`
- https://github.com/gregnb/react-to-print/issues/254 Ensure the `onload` event listener is cleared after being called
- Added a FAQ answer about how we don't control settings in the print dialog