### PR TITLE
Add nonce property for whitelisting script and style -elements for CSP (content security policy)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,8 @@ export interface IReactToPrintProps {
     suppressErrors?: boolean;
     /** Trigger action used to open browser print */
     trigger?: <T>() => React.ReactElement<ITriggerProps<T>>;
+    /** Set the nonce attribute for whitelisting script and style -elements for CSP (content security policy) */
+    nonce?: string;
 }
 
 export default class ReactToPrint extends React.Component<IReactToPrintProps> {
@@ -167,6 +169,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
             copyStyles,
             pageStyle,
             suppressErrors,
+            nonce,
         } = this.props;
 
         const contentEl = content();
@@ -240,6 +243,10 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                 const defaultPageStyle = typeof pageStyle === "function" ? pageStyle() : pageStyle;
 
                 const styleEl = domDoc.createElement("style");
+                if (nonce) {
+                    styleEl.setAttribute("nonce", nonce);
+                    domDoc.head.setAttribute("nonce", nonce);
+                }
                 // TODO: TS 3 should have removed the need for the `!`, so why is it still needed?
                 // https://github.com/Microsoft/TypeScript/issues/23812
                 styleEl.appendChild(domDoc.createTextNode(defaultPageStyle!));
@@ -294,6 +301,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                                     }
                                 }
                                 newHeadEl.setAttribute("id", `react-to-print-${i}`);
+                                nonce && newHeadEl.setAttribute("nonce", nonce);
                                 newHeadEl.appendChild(domDoc.createTextNode(styleCSS));
                                 domDoc.head.appendChild(newHeadEl);
                             }
@@ -318,6 +326,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
 
                                 newHeadEl.onload = markLoaded.bind(null, newHeadEl, true);
                                 newHeadEl.onerror = markLoaded.bind(null, newHeadEl, false);
+                                nonce && newHeadEl.setAttribute("nonce", nonce);
                                 domDoc.head.appendChild(newHeadEl);
                             } else {
                                 if (!suppressErrors) {
@@ -359,7 +368,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
             const value = {handlePrint: this.handleClick};
             if (!PrintContext) {
                 if (!suppressErrors) {
-                    console.error('"react-to-print" requires React ^16.3.0 to be able to use "PrintContext"'); // eslint-disable-line no-console 
+                    console.error('"react-to-print" requires React ^16.3.0 to be able to use "PrintContext"'); // eslint-disable-line no-console
                 }
                 return null;
             }


### PR DESCRIPTION
Hello,
React-to-print did not work for my project which has strict content security policy: https://www.w3.org/TR/CSP3/ 
It does not allow to copy script and style elements inside iframe component. The workaround is to add support for nonce property.