### PR TITLE
Split bodyClass string to allow multiple body classes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -252,7 +252,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                 domDoc.head.appendChild(styleEl);
 
                 if (bodyClass) {
-                    domDoc.body.classList.add(bodyClass);
+                    domDoc.body.classList.add(...bodyClass.split(" "));
                 }
 
                 const canvasEls = domDoc.querySelectorAll("canvas");


### PR DESCRIPTION
From issue #295, simply allow for a bodyClass string with multiple class names and spread them as arguments for `classList.add` method.

Passing this prop would throw an error and the print would never render.
```
bodyClass="firstClass secondClass"
```

With this fix, you are allowed to pass more than 1 class names without error.