### PR TITLE
`img` tags missing `src` attributes should not prevent printing

### DIFF
--- a/examples/ComponentToPrint/index.tsx
+++ b/examples/ComponentToPrint/index.tsx
@@ -42,6 +42,7 @@ export class ComponentToPrint extends React.PureComponent<Props, State> {
       <div className="relativeCSS">
         <div className="flash" />
         <img alt="A test image" src={image as string} />
+        <img alt="This will warn but not block printing" />
         <table className="testClass">
           <thead>
           <tr>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -323,6 +323,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                         if (!imgSrc) {
                             if (!suppressErrors) {
                                 console.warn('"react-to-print" encountered an <img> tag with an empty "src" attribute. It will not attempt to pre-load it. The <img> is:', imgNode); // eslint-disable-line no-console
+                                markLoaded(imgNode, false);
                             }
                         } else {
                             // https://stackoverflow.com/questions/10240110/how-do-you-cache-an-image-in-javascript


### PR DESCRIPTION
Fixes #378 