### PR TITLE
Be less strict about what the `tagName` of a `<style>` tag must be

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -410,7 +410,7 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                     const headEls = document.querySelectorAll("style, link[rel='stylesheet']");
                     for (let i = 0, headElsLen = headEls.length; i < headElsLen; ++i) {
                         const node = headEls[i];
-                        if (node.tagName === "STYLE") { // <style> nodes
+                        if (node.tagName.toLowerCase() === 'style') { // <style> nodes
                             const newHeadEl = domDoc.createElement(node.tagName);
                             const sheet = (node as HTMLStyleElement).sheet as CSSStyleSheet;
                             if (sheet) {


### PR DESCRIPTION
Fixes #485 

Currently we check to see if a node is a `<style>` tag by checking
if the `node.tagName === 'STYLE'`. However, it seems in some cases
it can be lowercase `'style'` instead, and possibly some browsers
or users might make it something else. This change adds resiliency
to the check.