### PR TITLE
Fix disabled node breaking the print

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -444,8 +444,8 @@ export default class ReactToPrint extends React.Component<IReactToPrintProps> {
                             // the current page. Some will attempt to load the page"s parent
                             // directory. These problems can cause `react-to-print` to stop without
                             // any error being thrown. To avoid such problems we simply do not
-                            // attempt to load these links.
-                            if (node.getAttribute("href")) {
+                            // attempt to load these links. 
+                            if (node.getAttribute("href") && !node.hasAttribute("disabled")) {
                                 const newHeadEl = domDoc.createElement(node.tagName);
 
                                 // Manually re-create the node


### PR DESCRIPTION
Print is not work if there is any disabled link node in the source content element.

Example:
here is a content element ready for print
```jsx
<div>
    <link rel="stylesheet" href="my-href-one"></link>
    <link disabled rel="stylesheet" href="my-href-two">
    </link>
    <div>
        My Content To Print
    </div>
</div>
```
A `disabled` attribute is set to the second link node, it never trigger `onload` or `onerror` callbacks after append it into an iframe.
FYI: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-disabled
So we can mark them loaded directly, otherwise, the `numResourcesManaged` is not equals to `this.linkTotal` in the `handlePrint` function
```tsx
  // numResourcesManaged always equals 1 and this.linkTotal always equals 2 in this case above
  if (numResourcesManaged === this.linkTotal) {
       this.triggerPrint(printWindow);
  }
```
 