### PR TITLE
Ensure `removeAfterPrint` and `onBeforePrint` wait for `print` to resolve

### DIFF
--- a/examples/CustomPrint/index.tsx
+++ b/examples/CustomPrint/index.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+
+import { ComponentToPrint } from "../ComponentToPrint";
+import ReactToPrint from "../../src/index";
+import { CUSTOM_FONTS } from "../fonts";
+
+export const CustomPrint = () => {
+  const componentRef = React.useRef(null);
+
+  const onBeforeGetContentResolve = React.useRef<(() => void) | null>(null);
+
+  const [loading, setLoading] = React.useState(false);
+  const [text, setText] = React.useState("Some cool text from the parent");
+
+  const handleAfterPrint = React.useCallback(() => {
+    console.log("`onAfterPrint` called"); // tslint:disable-line no-console
+  }, []);
+
+  const handleBeforePrint = React.useCallback(() => {
+    console.log("`onBeforePrint` called"); // tslint:disable-line no-console
+  }, []);
+
+  const handleOnBeforeGetContent = React.useCallback(() => {
+    console.log("`onBeforeGetContent` called"); // tslint:disable-line no-console
+    setLoading(true);
+    setText("Loading new text...");
+
+    return new Promise<void>((resolve) => {
+      onBeforeGetContentResolve.current = resolve;
+
+      setTimeout(() => {
+        setLoading(false);
+        setText("New, Updated Text!");
+        resolve();
+      }, 2000);
+    });
+  }, [setLoading, setText]);
+
+  React.useEffect(() => {
+    if (text === "New, Updated Text!" && typeof onBeforeGetContentResolve.current === "function") {
+      onBeforeGetContentResolve.current();
+    }
+  }, [onBeforeGetContentResolve.current, text]);
+
+  const reactToPrintContent = React.useCallback(() => {
+    return componentRef.current;
+  }, [componentRef.current]);
+
+  const reactToPrintTrigger = React.useCallback(() => {
+    // NOTE: could just as easily return <SomeComponent />. Do NOT pass an `onClick` prop
+    // to the root node of the returned component as it will be overwritten.
+
+    // Bad: the `onClick` here will be overwritten by `react-to-print`
+    // return <button onClick={() => alert('This will not work')}>Print this out!</button>;
+
+    // Good
+    return <button>Print using a custom print method (check dev console)</button>;
+  }, []);
+
+  return (
+    <div>
+      <ReactToPrint
+        content={reactToPrintContent}
+        documentTitle="AwesomeFileName"
+        onAfterPrint={handleAfterPrint}
+        onBeforeGetContent={handleOnBeforeGetContent}
+        onBeforePrint={handleBeforePrint}
+        print={(iframe) => {
+            return new Promise<void>((resolve) => {
+                console.log("Custom printing, 1.5 second mock delay...");
+                setTimeout(() => {
+                    console.log("Mock custom print of iframe complete", iframe);
+                    resolve();
+                }, 1500);
+            });
+        }}
+        removeAfterPrint
+        trigger={reactToPrintTrigger}
+        fonts={CUSTOM_FONTS}
+      />
+      {loading && <p className="indicator">onBeforeGetContent: Loading...</p>}
+      <ComponentToPrint ref={componentRef} text={text} />
+    </div>
+  );
+};

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -6,6 +6,7 @@ import 'react-tabs/style/react-tabs.css';
 import { ClassComponent } from "./ClassComponent";
 import { ClassComponentContextConsumer } from "./ClassComponentContextConsumer";
 import { ClassComponentText } from "./ClassComponentText";
+import { CustomPrint } from "./CustomPrint";
 import { FunctionalComponent } from "./FunctionalComponent";
 import { FunctionalComponentWithHook } from "./FunctionalComponentWithHook";
 import { FunctionalComponentWithFunctionalComponentToPrint } from './FunctionalComponentWithFunctionalComponentToPrint';
@@ -26,7 +27,7 @@ class Example extends React.Component<Props, State> {
           <TabList>
             <Tab>Class Component</Tab>
             <Tab>Functional Component</Tab>
-            <Tab>Raw Values</Tab>
+            <Tab>Other Examples</Tab>
           </TabList>
           <TabPanel>
             <Tabs>
@@ -53,9 +54,11 @@ class Example extends React.Component<Props, State> {
           <TabPanel>
             <Tabs>
               <TabList>
-                <Tab>Text</Tab>
+                <Tab>Raw Value: Text</Tab>
+                <Tab>Custom Print Function</Tab>
               </TabList>
               <TabPanel><ClassComponentText /></TabPanel>
+              <TabPanel><CustomPrint /></TabPanel>
             </Tabs>
           </TabPanel>
         </Tabs>


### PR DESCRIPTION
Fixes https://github.com/gregnb/react-to-print/issues/616

Recommend turning off whitespace when looking at this diff.

- Added an example to cover this usage for testing pruposes