### PR TITLE
Improve content handling for canvas and inputs

### DIFF
--- a/examples/ComponentToPrint/index.tsx
+++ b/examples/ComponentToPrint/index.tsx
@@ -15,11 +15,6 @@ export const ComponentToPrint = React.forwardRef<HTMLDivElement | null, Componen
   const { text } = props;
 
   const canvasEl = React.useRef<HTMLCanvasElement>(null);
-  const [checked, setChecked] = React.useState(false);
-
-  const handleCheckboxOnChange = React.useCallback(() => {
-    setChecked(!!checked);
-  }, [checked]);
 
   React.useEffect(() => {
     const ctx = canvasEl.current?.getContext("2d");
@@ -115,11 +110,7 @@ export const ComponentToPrint = React.forwardRef<HTMLDivElement | null, Componen
           <tr>
             <td>Input: Checkbox</td>
             <td>
-              <input
-                checked={checked}
-                onChange={handleCheckboxOnChange}
-                type="checkbox"
-              />
+              <input type="checkbox" />
             </td>
           </tr>
           <tr>

--- a/src/hooks/useReactToPrint.ts
+++ b/src/hooks/useReactToPrint.ts
@@ -49,19 +49,20 @@ export function useReactToPrint(options: UseReactToPrintOptions): UseReactToPrin
             return;
         }
 
-        // React components can return a bare string as a valid JSX response
+        // NOTE: `canvas` elements do not have their painted images copied
+        // https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode
         const clonedContentNode = contentNode.cloneNode(true);
 
         const globalLinkNodes = document.querySelectorAll("link[rel~='stylesheet'], link[as='style']");
-        const renderComponentImgNodes = (clonedContentNode as Element).querySelectorAll("img");
-        const renderComponentVideoNodes = (clonedContentNode as Element).querySelectorAll("video");
+        const clonedImgNodes = (clonedContentNode as Element).querySelectorAll("img");
+        const clonedVideoNodes = (clonedContentNode as Element).querySelectorAll("video");
 
         const numFonts = fonts ? fonts.length : 0;
 
         const numResourcesToLoad =
             (ignoreGlobalStyles ? 0 : globalLinkNodes.length) +
-            renderComponentImgNodes.length +
-            renderComponentVideoNodes.length +
+            clonedImgNodes.length +
+            clonedVideoNodes.length +
             numFonts;
         const resourcesLoaded: (Element | Font | FontFace)[] = [];
         const resourcesErrored: (Element | Font | FontFace)[] = [];
@@ -106,10 +107,10 @@ export function useReactToPrint(options: UseReactToPrintOptions): UseReactToPrin
 
         const data: HandlePrintWindowOnLoadData = {
             clonedContentNode,
-            contentNode,
+            clonedImgNodes,
+            clonedVideoNodes,
             numResourcesToLoad,
-            renderComponentImgNodes,
-            renderComponentVideoNodes,
+            originalCanvasNodes: (contentNode as Element).querySelectorAll("canvas")
         }
 
         // Ensure we run `onBeforePrint` before appending the print window, which kicks off loading

--- a/src/utils/appendPrintWindow.ts
+++ b/src/utils/appendPrintWindow.ts
@@ -3,6 +3,7 @@ import { UseReactToPrintOptions } from "../types/UseReactToPrintOptions";
 import { handlePrintWindowOnLoad, HandlePrintWindowOnLoadData } from "./handlePrintWindowOnLoad";
 
 export function appendPrintWindow(
+    /** The print iframe */
     printWindow: HTMLIFrameElement,
     markLoaded: (resource: Element | Font | FontFace, errorMessages?: unknown[]) => void,
     data: HandlePrintWindowOnLoadData,

--- a/src/utils/logMessage.ts
+++ b/src/utils/logMessage.ts
@@ -7,7 +7,8 @@ type LogMessagesArgs = {
     suppressErrors?: boolean;
 }
 
-export function logMessages({level = 'error', messages, suppressErrors = false }: LogMessagesArgs) {
+/** Logs messages to the console. Uses `console.error` by default. */
+export function logMessages({ level = 'error', messages, suppressErrors = false }: LogMessagesArgs) {
     if (!suppressErrors) {
         if (level === 'error') {
             console.error(messages); // eslint-disable-line no-console


### PR DESCRIPTION
- Improve handling when iterating over `canvas` elements since these need to operate against the original content which may not be ready: https://github.com/MatthewHerbst/react-to-print/issues/707
- Remove legacy input/checkbox/select copying, all major browsers natively support this
