### PR TITLE
Handle hook fn being passed to event handlers raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Print the content of a React component.
 
 ```tsx
 const contentRef = useRef<HTMLDivElement>(null);
-const handlePrint = useReactToPrint({ contentRef });
+const reactToPrintFn = useReactToPrint({ contentRef });
 
 return (
   <div>
-    <button onClick={handlePrint}>Print</button>
+    <button onClick={reactToPrintFn}>Print</button>
     <div ref={contentRef}>Content to print</div>
   </div>
 );

--- a/examples/BasicComponent/index.tsx
+++ b/examples/BasicComponent/index.tsx
@@ -27,13 +27,10 @@ export const BasicComponent = () => {
     onBeforePrint: handleBeforePrint,
   }); 
 
-  const handleOnClick = React.useCallback(() => {
-    printFn();
-  }, [printFn]);
-
   return (
     <div>
-      <button onClick={handleOnClick}>Print</button>
+      {/* @ts-expect-error Works without lazy content wrapping */}
+      <button onClick={printFn}>Print</button>
       <ComponentToPrint ref={componentRef} />
     </div>
   );

--- a/src/hooks/useReactToPrint.ts
+++ b/src/hooks/useReactToPrint.ts
@@ -41,14 +41,6 @@ export function useReactToPrint(options: UseReactToPrintOptions): UseReactToPrin
             return;
         }
 
-        if (!contentNode) {
-            logMessages({
-                messages: ['"react-to-print" could not locate the DOM node corresponding with the `content` prop'],
-                suppressErrors,
-            });
-            return;
-        }
-
         // NOTE: `canvas` elements do not have their painted images copied
         // https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode
         const clonedContentNode = contentNode.cloneNode(true);

--- a/src/utils/getContentNode.ts
+++ b/src/utils/getContentNode.ts
@@ -18,7 +18,12 @@ export function getContentNode({ contentRef, optionalContent, suppressErrors }: 
             });
         }
 
-        return optionalContent();
+        // This check allows passing the callback from `useReactToPrint` directly into event
+        // handlers without having to wrap it in another function to capture the event
+        // See [#742](https://github.com/MatthewHerbst/react-to-print/issues/742) and [#724](https://github.com/MatthewHerbst/react-to-print/issues/724)
+        if (typeof optionalContent === "function")   {
+            return optionalContent();
+        }
     }
 
     if (contentRef) {


### PR DESCRIPTION
- Allow passing the callback directly to event handlers
- Remove useless error check left over from v2