### PR TITLE
Implement workaround for print iframe removal on focus event

### DIFF
--- a/src/utils/startPrint.ts
+++ b/src/utils/startPrint.ts
@@ -75,8 +75,19 @@ export function startPrint(printWindow: HTMLIFrameElement, options: UseReactToPr
                     });
                 }
 
-                onAfterPrint?.();
-                removePrintIframe(preserveAfterPrint);
+                /**
+				 * Remove the print iframe after the print dialog closes that determined by the main
+				 * window is regaining focus after the print dialog closes. This workaround is applied
+				 * due to the lack of a reliable `afterprint` event in most browsers.
+				 */
+				window.addEventListener(
+					"focus",
+					() => {
+						onAfterPrint?.();
+						removePrintIframe(preserveAfterPrint);
+					},
+					{ once: true }
+				);
             }
         } else {
             logMessages({


### PR DESCRIPTION
This pull request introduces an important update to the `startPrint` function in the `src/utils/startPrint.ts` file. The update implements a workaround to address the issue where the print iframe is removed immediately after the print dialog closes. This fixes the problem described in issue #187, where the iframe was being removed too early—before the print dialog appeared—causing the print preview to display the entire UI instead of the intended content.

* [`src/utils/startPrint.ts`](diffhunk://#diff-f9538760ee08f21e6507942479209741c43ae72102c42f8f6d4acfe09c5eed93R78-R90): Added a `focus` event listener to remove the print iframe after the print dialog closes, addressing the lack of a reliable `afterprint` event in most browsers.