### PR TITLE
execution exception for empty video src

### DIFF
--- a/src/utils/handlePrintWindowOnLoad.ts
+++ b/src/utils/handlePrintWindowOnLoad.ts
@@ -188,7 +188,9 @@ export function handlePrintWindowOnLoad(
             } else {
                 if (videoNode.readyState >= 2) { // Check if the video has already loaded a frame
                     markLoaded(videoNode);
-                } else {
+                } else if (!videoNode.src) {
+                    markLoaded(videoNode, ["video src empty", videoNode, "Error"]);
+                } else{
                     videoNode.onloadeddata = () => {
                         markLoaded(videoNode)
                     };


### PR DESCRIPTION
when using vidstack/player to play videos, if the area where the video is rendered is not scrolled, the video src will be empty at this time. After calling reactToPrint, the browser's printing function will not be invoked and no errors will be thrown.
