### PR TITLE
Allow passing the `useReactToPrint` callback directly to event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const reactToPrintFn = useReactToPrint({ contentRef });
 
 return (
   <div>
-    <button onClick={() => reactToPrintFn()}>Print</button>
+    <button onClick={reactToPrintFn}>Print</button>
     <div ref={contentRef}>Content to print</div>
   </div>
 );

--- a/examples/BasicComponent/index.tsx
+++ b/examples/BasicComponent/index.tsx
@@ -29,7 +29,6 @@ export const BasicComponent = () => {
 
   return (
     <div>
-      {/* @ts-expect-error Works without lazy content wrapping */}
       <button onClick={printFn}>Print</button>
       <ComponentToPrint ref={componentRef} />
     </div>

--- a/examples/CopyShadowRootContent/index.tsx
+++ b/examples/CopyShadowRootContent/index.tsx
@@ -22,13 +22,9 @@ export const CopyShadowRootContent = () => {
     copyShadowRoots: true
   });
 
-  const handleOnClick = React.useCallback(() => {
-    printFn();
-  }, [printFn]);
-
   return (
     <div>
-      <button onClick={handleOnClick}>Print</button>
+      <button onClick={printFn}>Print</button>
       <ComponentToPrint ref={componentRef} />
     </div>
   );

--- a/examples/CustomPrint/index.tsx
+++ b/examples/CustomPrint/index.tsx
@@ -25,14 +25,10 @@ export const CustomPrint = () => {
     },
   }); 
 
-  const handleOnClick = React.useCallback(() => {
-    printFn();
-  }, [printFn]);
-
   return (
     <div>
       <h3>See console for output: print window will not open</h3>
-      <button onClick={handleOnClick}>Print</button>
+      <button onClick={printFn}>Print</button>
       <ComponentToPrint ref={componentRef} />
     </div>
   );

--- a/examples/OnBeforePrint/index.tsx
+++ b/examples/OnBeforePrint/index.tsx
@@ -52,13 +52,9 @@ export const OnBeforePrint = () => {
     onBeforePrint: handleOnBeforePrint,
   }); 
 
-  const handleOnClick = React.useCallback(() => {
-    printFn();
-  }, [printFn]);
-
   return (
     <div>
-      <button onClick={handleOnClick}>Print</button>
+      <button onClick={printFn}>Print</button>
       {loading && <p className="indicator">onBeforePrint: Loading...</p>}
       <ComponentToPrint ref={componentRef} text={text} />
     </div>

--- a/src/types/UseReactToPrintHookContent.ts
+++ b/src/types/UseReactToPrintHookContent.ts
@@ -1,3 +1,7 @@
 import { ContentNode } from "./ContentNode";
 
-export type UseReactToPrintHookContent = () => ContentNode;
+/**
+ * `Event` allowed so that the `useReactToPrint` callback can be passed directly to an event
+ * handler rather than needing to be wrapped.
+ */
+export type UseReactToPrintHookContent = React.UIEvent | (() => ContentNode);

--- a/src/utils/getContentNode.ts
+++ b/src/utils/getContentNode.ts
@@ -10,7 +10,9 @@ interface GetContentNodesArgs {
 }
 
 export function getContentNode({ contentRef, optionalContent, suppressErrors }: GetContentNodesArgs): ContentNode {
-    if (optionalContent) {
+    // This `Event` check allows passing the callback from `useReactToPrint` directly into event
+    // handlers without having to wrap it in another function to capture the event
+    if (optionalContent && !(optionalContent instanceof Event)) {
         if (contentRef) {
             logMessages({
                 level: "warning",
@@ -18,8 +20,6 @@ export function getContentNode({ contentRef, optionalContent, suppressErrors }: 
             });
         }
 
-        // This check allows passing the callback from `useReactToPrint` directly into event
-        // handlers without having to wrap it in another function to capture the event
         // See [#742](https://github.com/MatthewHerbst/react-to-print/issues/742) and [#724](https://github.com/MatthewHerbst/react-to-print/issues/724)
         if (typeof optionalContent === "function")   {
             return optionalContent();


### PR DESCRIPTION
This resolves a large source of v3 upgrade pain which required changing `onClick={printFn}` to `onClick={() => printFn()}`