### PR TITLE
Correct issues with `onBeforePrint`

### DIFF
--- a/examples/OnBeforePrint/index.tsx
+++ b/examples/OnBeforePrint/index.tsx
@@ -13,7 +13,7 @@ export const OnBeforePrint = () => {
   const onBeforePrintResolve = React.useRef<(() => void) | null>(null);
 
   const [loading, setLoading] = React.useState(false);
-  const [text, setText] = React.useState("Some cool text from the parent");
+  const [text, setText] = React.useState("Some cool original text");
 
   const handleOnAfterPrint = React.useCallback(() => {
     console.log("`onAfterPrint` called"); // tslint:disable-line no-console
@@ -32,7 +32,6 @@ export const OnBeforePrint = () => {
       setTimeout(() => {
         setLoading(false);
         setText("New, Updated Text!");
-        resolve();
       }, 2000);
     });
   }, [setLoading, setText]);
@@ -41,6 +40,7 @@ export const OnBeforePrint = () => {
     if (text === "New, Updated Text!" && typeof onBeforePrintResolve.current === "function") {
       console.log("State update applied, resolving the promise for `onBeforePrint`"); // tslint:disable-line no-console
       onBeforePrintResolve.current();
+      onBeforePrintResolve.current = null;
     }
   }, [onBeforePrintResolve.current, text]);
 

--- a/src/hooks/useReactToPrint.ts
+++ b/src/hooks/useReactToPrint.ts
@@ -1,17 +1,15 @@
 import { useCallback } from "react";
 
-import { Font } from "../types/font";
 import type { UseReactToPrintOptions } from "../types/UseReactToPrintOptions";
-import { getContentNode } from "../utils/getContentNode";
 import { generatePrintWindow } from "../utils/generatePrintWindow";
 import { logMessages } from "../utils/logMessage";
 import { UseReactToPrintHookContent } from "../types/UseReactToPrintHookContent";
-import { HandlePrintWindowOnLoadData } from "../utils/handlePrintWindowOnLoad";
 import { removePrintIframe } from "../utils/removePrintIframe";
 import { UseReactToPrintFn } from "../types/UseReactToPrintFn";
 import { appendPrintWindow } from "../utils/appendPrintWindow";
-import { startPrint } from "../utils/startPrint";
 import { getErrorFromUnknown } from "../utils/getErrorMessage";
+import { getPrintData } from "../utils/getPrintData";
+import { getMarkedLoaded } from "../utils/getMarkedLoaded";
 
 export function useReactToPrint({
     bodyClass,
@@ -30,116 +28,56 @@ export function useReactToPrint({
     suppressErrors,
 }: UseReactToPrintOptions): UseReactToPrintFn {
     const handlePrint = useCallback((optionalContent?: UseReactToPrintHookContent) => {
-        const options = {
-            bodyClass,
-            contentRef,
-            copyShadowRoots,
-            documentTitle,
-            fonts,
-            ignoreGlobalStyles,
-            nonce,
-            onAfterPrint,
-            onBeforePrint,
-            onPrintError,
-            pageStyle,
-            preserveAfterPrint,
-            print,
-            suppressErrors,
-          };
         // Ensure we remove any pre-existing print windows before adding a new one
         removePrintIframe(preserveAfterPrint, true);
 
-        const contentNode = getContentNode({
-            contentRef,
-            optionalContent,
-            suppressErrors,
-        });
-
-        if (!contentNode) {
-            logMessages({
-                messages: ['There is nothing to print'],
+        function beginPrint() {
+            const options: UseReactToPrintOptions = {
+                bodyClass,
+                contentRef,
+                copyShadowRoots,
+                documentTitle,
+                fonts,
+                ignoreGlobalStyles,
+                nonce,
+                onAfterPrint,
+                onBeforePrint,
+                onPrintError,
+                pageStyle,
+                preserveAfterPrint,
+                print,
                 suppressErrors,
-            });
-            return;
-        }
+            };
+            
+            const printWindow = generatePrintWindow();
+            const data = getPrintData(optionalContent, options);
 
-        // NOTE: `canvas` elements do not have their painted images copied
-        // https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode
-        const clonedContentNode = contentNode.cloneNode(true);
-
-        const globalLinkNodes = document.querySelectorAll("link[rel~='stylesheet'], link[as='style']");
-        const clonedImgNodes = (clonedContentNode as Element).querySelectorAll("img");
-        const clonedVideoNodes = (clonedContentNode as Element).querySelectorAll("video");
-
-        const numFonts = fonts ? fonts.length : 0;
-
-        const numResourcesToLoad =
-            (ignoreGlobalStyles ? 0 : globalLinkNodes.length) +
-            clonedImgNodes.length +
-            clonedVideoNodes.length +
-            numFonts;
-        const resourcesLoaded: (Element | Font | FontFace)[] = [];
-        const resourcesErrored: (Element | Font | FontFace)[] = [];
-
-        const printWindow = generatePrintWindow();
-
-        /**
-         * Keeps track of loaded resources, kicking off the actual print function once all
-         * resources have been marked (loaded or failed)
-         */
-        const markLoaded = (resource: Element | Font | FontFace, errorMessages?: unknown[]) => {
-            if (resourcesLoaded.includes(resource)) {
+            if (!data) {
                 logMessages({
-                    level: "debug",
-                    messages: ["Tried to mark a resource that has already been handled", resource],
+                    messages: ['There is nothing to print'],
                     suppressErrors,
                 });
                 return;
             }
 
-            if (!errorMessages) {
-                resourcesLoaded.push(resource);
-            } else {
-                logMessages({
-                    messages: [
-                        '"react-to-print" was unable to load a resource but will continue attempting to print the page',
-                        ...errorMessages
-                    ],
-                    suppressErrors,
-                });
-                resourcesErrored.push(resource);
-            }
-
-            // We may have errors, but attempt to print anyways - maybe they are trivial and the
-            // user will be ok ignoring them
-            const numResourcesManaged = resourcesLoaded.length + resourcesErrored.length;
-
-            if (numResourcesManaged === numResourcesToLoad) {
-                startPrint(printWindow, options);
-            }
-        };
-
-        const data: HandlePrintWindowOnLoadData = {
-            contentNode,
-            clonedContentNode,
-            clonedImgNodes,
-            clonedVideoNodes,
-            numResourcesToLoad,
-            originalCanvasNodes: (contentNode as Element).querySelectorAll("canvas")
+            const markLoaded = getMarkedLoaded(options, data.numResourcesToLoad, printWindow);
+            appendPrintWindow(printWindow, markLoaded, data, options);
         }
 
         // Ensure we run `onBeforePrint` before appending the print window, which kicks off loading
         // needed resources once mounted
+        // TODO: At this point we should remove `onBeforePrint` completely and just have consumers
+        // call the print function when they are ready. 
         if (onBeforePrint) {
             onBeforePrint()
                 .then(() => {
-                    appendPrintWindow(printWindow, markLoaded, data, options);
+                    beginPrint();
                 })
                 .catch((error: unknown) => {
                     onPrintError?.("onBeforePrint", getErrorFromUnknown(error));
                 });
         } else {
-            appendPrintWindow(printWindow, markLoaded, data, options);
+            beginPrint();
         }
     }, [
         bodyClass,
@@ -156,7 +94,7 @@ export function useReactToPrint({
         preserveAfterPrint,
         print,
         suppressErrors,
-      ]);
+    ]);
 
     return handlePrint;
 }

--- a/src/utils/getMarkedLoaded.ts
+++ b/src/utils/getMarkedLoaded.ts
@@ -1,0 +1,53 @@
+import type { Font } from "../types/font";
+import type { UseReactToPrintOptions } from "../types/UseReactToPrintOptions";
+import { logMessages } from "./logMessage";
+import { startPrint } from "./startPrint";
+
+export function getMarkedLoaded(
+    options: UseReactToPrintOptions,
+    numResourcesToLoad: number,
+    printWindow: HTMLIFrameElement,
+) {
+    const {
+        suppressErrors,
+    } = options;
+
+    const resourcesLoaded: (Element | Font | FontFace)[] = [];
+    const resourcesErrored: (Element | Font | FontFace)[] = [];
+
+    /**
+     * Keeps track of loaded resources, kicking off the actual print function once all
+     * resources have been marked (loaded or failed)
+     */
+    return function markLoaded(resource: Element | Font | FontFace, errorMessages?: unknown[]) {
+        if (resourcesLoaded.includes(resource)) {
+            logMessages({
+                level: "debug",
+                messages: ["Tried to mark a resource that has already been handled", resource],
+                suppressErrors,
+            });
+            return;
+        }
+
+        if (!errorMessages) {
+            resourcesLoaded.push(resource);
+        } else {
+            logMessages({
+                messages: [
+                    '"react-to-print" was unable to load a resource but will continue attempting to print the page',
+                    ...errorMessages
+                ],
+                suppressErrors,
+            });
+            resourcesErrored.push(resource);
+        }
+
+        // We may have errors, but attempt to print anyways - maybe they are trivial and the
+        // user will be ok ignoring them
+        const numResourcesManaged = resourcesLoaded.length + resourcesErrored.length;
+
+        if (numResourcesManaged === numResourcesToLoad) {
+            startPrint(printWindow, options);
+        }
+    };
+}

--- a/src/utils/getPrintData.ts
+++ b/src/utils/getPrintData.ts
@@ -1,0 +1,52 @@
+import type { UseReactToPrintHookContent } from "../types/UseReactToPrintHookContent";
+import type { UseReactToPrintOptions } from "../types/UseReactToPrintOptions";
+import { getContentNode } from "./getContentNode";
+import type { HandlePrintWindowOnLoadData } from "./handlePrintWindowOnLoad";
+
+/** Returns `undefined` if there is nothing to print */
+export function getPrintData(
+    optionalContent: UseReactToPrintHookContent | undefined,
+    options: UseReactToPrintOptions,
+): HandlePrintWindowOnLoadData | undefined {
+    const {
+        contentRef,
+        fonts,
+        ignoreGlobalStyles,
+        suppressErrors,
+    } = options;
+
+    const contentNode = getContentNode({
+        contentRef,
+        optionalContent,
+        suppressErrors,
+    });
+
+    if (!contentNode) {
+        return;
+    }
+
+    // NOTE: `canvas` elements do not have their painted images copied
+    // https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode
+    const clonedContentNode = contentNode.cloneNode(true);
+
+    const globalLinkNodes = document.querySelectorAll("link[rel~='stylesheet'], link[as='style']");
+    const clonedImgNodes = (clonedContentNode as Element).querySelectorAll("img");
+    const clonedVideoNodes = (clonedContentNode as Element).querySelectorAll("video");
+
+    const numFonts = fonts ? fonts.length : 0;
+
+    const numResourcesToLoad =
+        (ignoreGlobalStyles ? 0 : globalLinkNodes.length) +
+        clonedImgNodes.length +
+        clonedVideoNodes.length +
+        numFonts;
+
+    return {
+        contentNode,
+        clonedContentNode,
+        clonedImgNodes,
+        clonedVideoNodes,
+        numResourcesToLoad,
+        originalCanvasNodes: (contentNode as Element).querySelectorAll("canvas")
+    };
+}


### PR DESCRIPTION
A new Chrome version has exposed some issues with `onBeforePrint` and the way we gather print content. This ensures we don't attempt to do any work, including gathering print document details or creating the print `iframe`, until `onBeforePrint` resolves