### PR TITLE
feat: allow specifying print iframe width and height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- FEAT [TBD](https://github.com/MatthewHerbst/react-to-print/pull/TBD): Allow specifying the print iframe's `width` and `height` via `printIframeProps` ([826](https://github.com/MatthewHerbst/react-to-print/issues/826))
+- FEAT [845](https://github.com/MatthewHerbst/react-to-print/pull/845): Allow specifying the print iframe's `width` and `height` via `printIframeProps` ([826](https://github.com/MatthewHerbst/react-to-print/issues/826))
 - CHORE [TBD](https://github.com/MatthewHerbst/react-to-print/pull/TBD): Minify the build with terser, shrinking the ESM (`.mjs`) bundle ~28% raw / ~18% gzipped
 - CHORE [TBD](https://github.com/MatthewHerbst/react-to-print/pull/TBD): Scope the `lint-staged` glob to `src/`, fixing a pre-commit crash when staging root config files
 - DOCS [TBD](https://github.com/MatthewHerbst/react-to-print/pull/TBD): Add README guidance on dark mode ([816](https://github.com/MatthewHerbst/react-to-print/issues/816)), Tailwind CSS ([784](https://github.com/MatthewHerbst/react-to-print/issues/784)), and content not wrapping to the next page ([819](https://github.com/MatthewHerbst/react-to-print/issues/819))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- FEAT [TBD](https://github.com/MatthewHerbst/react-to-print/pull/TBD): Allow specifying the print iframe's `width` and `height` via `printIframeProps` ([826](https://github.com/MatthewHerbst/react-to-print/issues/826))
+
 ## 3.3.0 (February 22nd, 2026)
 
 - CHORE [838](https://github.com/MatthewHerbst/react-to-print/pull/838): Update most dev dependencies

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is also possible to lazy set the ref if your content being printed is dynamic
 | **`pageStyle`** | `string` | `react-to-print` sets some basic styles to help improve page printing, notably, removing the header and footer that most browsers add. Use this to override these styles and provide your own |
 | **`preserveAfterPrint`** | `boolean` | Preserve the print iframe after printing. This can be useful for debugging by inspecting the print iframe |
 | **`print`** | `(iframe: HTMLIFrameElement) => Promise<void>` | If passed, this function will be used instead of `window.print` to print the content. Use this to print in non-browser environments such as Electron |
-| **`printIframeProps`** | `{ allow?: string, referrerPolicy?: HTMLAttributeReferrerPolicy, sandbox?: string }` | Allows setting certain properties of the print iframe, primarily for privacy and security policies |
+| **`printIframeProps`** | `{ allow?: string, referrerPolicy?: HTMLAttributeReferrerPolicy, sandbox?: string, width?: string \| number, height?: string \| number }` | Allows setting certain properties of the print iframe, primarily for privacy and security policies. `width`/`height` set the iframe's size (defaulting to the document's client size); some content, particularly responsive layouts, may render differently depending on the iframe size |
 | **`suppressErrors`** | `boolean` | When passed, prevents `console` logging of errors |
 
 ## Compatibility

--- a/src/types/UseReactToPrintOptions.ts
+++ b/src/types/UseReactToPrintOptions.ts
@@ -64,6 +64,12 @@ export interface UseReactToPrintOptions {
      */
     printIframeProps?: {
         allow?: IframeHTMLAttributes<HTMLIFrameElement>["allow"],
+        /**
+         * The height of the print iframe. Accepts any valid value for the iframe `height` attribute
+         * (e.g. a pixel count like `"600"`). Defaults to the document's client height. Some content,
+         * particularly responsive layouts, may render differently depending on the iframe size
+         */
+        height?: IframeHTMLAttributes<HTMLIFrameElement>["height"],
         referrerPolicy?: IframeHTMLAttributes<HTMLIFrameElement>["referrerPolicy"],
         sandbox?: IframeHTMLAttributes<HTMLIFrameElement>["sandbox"],
         /**
@@ -72,12 +78,7 @@ export interface UseReactToPrintOptions {
          * particularly responsive layouts, may render differently depending on the iframe size
          */
         width?: IframeHTMLAttributes<HTMLIFrameElement>["width"],
-        /**
-         * The height of the print iframe. Accepts any valid value for the iframe `height` attribute
-         * (e.g. a pixel count like `"600"`). Defaults to the document's client height. Some content,
-         * particularly responsive layouts, may render differently depending on the iframe size
-         */
-        height?: IframeHTMLAttributes<HTMLIFrameElement>["height"],
+
     };
     /** When passed, prevents `console` logging of errors */
     suppressErrors?: boolean;

--- a/src/types/UseReactToPrintOptions.ts
+++ b/src/types/UseReactToPrintOptions.ts
@@ -66,6 +66,18 @@ export interface UseReactToPrintOptions {
         allow?: IframeHTMLAttributes<HTMLIFrameElement>["allow"],
         referrerPolicy?: IframeHTMLAttributes<HTMLIFrameElement>["referrerPolicy"],
         sandbox?: IframeHTMLAttributes<HTMLIFrameElement>["sandbox"],
+        /**
+         * The width of the print iframe. Accepts any valid value for the iframe `width` attribute
+         * (e.g. a pixel count like `"800"`). Defaults to the document's client width. Some content,
+         * particularly responsive layouts, may render differently depending on the iframe size
+         */
+        width?: IframeHTMLAttributes<HTMLIFrameElement>["width"],
+        /**
+         * The height of the print iframe. Accepts any valid value for the iframe `height` attribute
+         * (e.g. a pixel count like `"600"`). Defaults to the document's client height. Some content,
+         * particularly responsive layouts, may render differently depending on the iframe size
+         */
+        height?: IframeHTMLAttributes<HTMLIFrameElement>["height"],
     };
     /** When passed, prevents `console` logging of errors */
     suppressErrors?: boolean;

--- a/src/utils/generatePrintWindow.ts
+++ b/src/utils/generatePrintWindow.ts
@@ -3,8 +3,12 @@ import { UseReactToPrintOptions } from "../types/UseReactToPrintOptions";
 
 export function generatePrintWindow(printIframeProps: UseReactToPrintOptions["printIframeProps"]): HTMLIFrameElement {
     const printWindow = document.createElement("iframe");
-    printWindow.width = `${document.documentElement.clientWidth}px`;
-    printWindow.height = `${document.documentElement.clientHeight}px`;
+    printWindow.width = printIframeProps?.width !== undefined
+        ? `${printIframeProps.width}`
+        : `${document.documentElement.clientWidth}px`;
+    printWindow.height = printIframeProps?.height !== undefined
+        ? `${printIframeProps.height}`
+        : `${document.documentElement.clientHeight}px`;
     printWindow.style.position = "absolute";
     printWindow.style.top = `-${document.documentElement.clientHeight + 100}px`;
     printWindow.style.left = `-${document.documentElement.clientWidth + 100}px`;


### PR DESCRIPTION
Adds optional `width` and `height` to `printIframeProps`. These default to the document's client width/height (the prior hardcoded behavior). Useful when content - particularly responsive layouts - renders differently depending on the iframe size.

Closes #826